### PR TITLE
chore: recommend npm-version-lens extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,32 +1,32 @@
 {
-    "recommendations": [
-        "ghmcadams.lintlens",
-        "dbaeumer.vscode-eslint",
-        "mgmcdermott.vscode-language-babel",
-        "adpyke.codesnap",
-        "editorconfig.editorconfig",
-        "mhutchie.git-graph",
-        "omartawfik.github-actions-vscode",
-        "github.copilot",
-        "eamodio.gitlens",
-        "wix.vscode-import-cost",
-        "orta.vscode-jest",
-        "bierner.markdown-preview-github-styles",
-        "pkief.material-icon-theme",
-        "christian-kohler.path-intellisense",
-        "mrmlnc.vscode-remark",
-        "foxundermoon.shell-format",
-        "sonarsource.sonarlint-vscode",
-        "trunk.io",
-        "pflannery.vscode-versionlens",
-        "redhat.vscode-yaml",
-        "eg2.vscode-npm-script",
-        "christian-kohler.npm-intellisense",
-        "yzhang.markdown-all-in-one",
-        "tlent.jest-snapshot-language-support"
-      ],
-      "unwantedRecommendations": [
-        "hookyqr.beautify",
-        "dbaeumer.jshint"
-      ]
+  "recommendations": [
+    "ghmcadams.lintlens",
+    "dbaeumer.vscode-eslint",
+    "mgmcdermott.vscode-language-babel",
+    "adpyke.codesnap",
+    "editorconfig.editorconfig",
+    "mhutchie.git-graph",
+    "omartawfik.github-actions-vscode",
+    "github.copilot",
+    "eamodio.gitlens",
+    "wix.vscode-import-cost",
+    "orta.vscode-jest",
+    "bierner.markdown-preview-github-styles",
+    "pkief.material-icon-theme",
+    "christian-kohler.path-intellisense",
+    "mrmlnc.vscode-remark",
+    "foxundermoon.shell-format",
+    "sonarsource.sonarlint-vscode",
+    "trunk.io",
+    "legalfina.npm-version-lens",
+    "redhat.vscode-yaml",
+    "eg2.vscode-npm-script",
+    "christian-kohler.npm-intellisense",
+    "yzhang.markdown-all-in-one",
+    "tlent.jest-snapshot-language-support"
+  ],
+  "unwantedRecommendations": [
+    "hookyqr.beautify",
+    "dbaeumer.jshint"
+  ]
 }


### PR DESCRIPTION
## Recommend npm-version-lens

This PR updates `.vscode/extensions.json` to recommend [**npm-version-lens**](https://marketplace.visualstudio.com/items?itemName=Legalfina.npm-version-lens) in place of the following extension(s):

- `pflannery.vscode-versionlens`

### Why?

**npm-version-lens** provides:
- Color-coded version indicators directly in `package.json`
- One-click version updates via an inline dropdown
- Inlay hints showing the latest available version

It is actively maintained and lightweight.

Marketplace: https://marketplace.visualstudio.com/items?itemName=Legalfina.npm-version-lens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VS Code extension recommendations configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->